### PR TITLE
End to end test to read from SQL and write to LevelDB.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3'
+services:
+  mysql: 
+    image: mysql:8.0
+    environment:
+      - MYSQL_ROOT_PASSWORD=test
+      - MYSQL_DATABASE=test
+      - MYSQL_PASSWORD=test
+      - MYSQL_USER=sql2kv
+    volumes:
+      - ./data/mysql:/var/lib/mysql
+    ports:
+      - 3306:3306

--- a/mapper.go
+++ b/mapper.go
@@ -1,72 +1,173 @@
 package sql2kv
 
 import (
+	"encoding/json"
 	"fmt"
+	"log"
+	"reflect"
+	"strings"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/syndtr/goleveldb/leveldb"
 )
 
-// Info Schema for mysql
+// ColumnSchema ...
 type ColumnSchema struct {
-	Database   string `db:"TABLE_SCHEMA"`
-	TableName  string `db:"TABLE_NAME"`
-	ColumnName string `db:"COLUMN_NAME"`
-	DataType   string `db:"DATA_TYPE"`
-	IsNullable string `db:"IS_NULLABLE"`
-	ColumnKey  string `db:"COLUMN_KEY"`
+	Database        string `db:"TABLE_SCHEMA"`
+	TableName       string `db:"TABLE_NAME"`
+	ColumnName      string `db:"COLUMN_NAME"`
+	DataType        string `db:"DATA_TYPE"`
+	IsNullable      string `db:"IS_NULLABLE"`
+	ColumnKey       string `db:"COLUMN_KEY"`
+	OrdinalPosition int    `db:"ORDINAL_POSITION"`
 }
 
+// TableSchema ...
 type TableSchema struct {
+	Schema     string
 	Name       string
 	Columns    []ColumnSchema
 	PrimaryKey string
 }
 
-func GetTableSchemas(db *sqlx.DB, schema string, tables []string) ([]TableSchema, error) {
+// ColumnNames returns a slice of column names. The ordering of this slice
+// affects the SQL statement yielded by QueryAll.
+func (ts TableSchema) ColumnNames() []string {
+	var res []string
+	for _, col := range ts.Columns {
+		res = append(res, col.ColumnName)
+	}
+	return res
+}
 
-	var results []TableSchema
+// QueryAll yields a SQL string that selects the entire table.
+func (ts TableSchema) QueryAll() string {
 
-	for _, t := range tables {
-		q := fmt.Sprintf(`Select 
+	var cols []string
+	for _, c := range ts.Columns {
+		cols = append(cols, c.ColumnName)
+	}
+
+	sql := fmt.Sprintf(`select %s from %s.%s ;`,
+		strings.Join(cols, ", "), ts.Schema, ts.Name)
+	return sql
+
+}
+
+// GetTableSchema ...
+func GetTableSchema(db *sqlx.DB, schema string, table string) (*TableSchema, error) {
+
+	tableSchema := TableSchema{schema, table, nil, ""}
+
+	q := fmt.Sprintf(`Select 
 		TABLE_SCHEMA,
 		TABLE_NAME,
 		COLUMN_NAME,
 		DATA_TYPE,
 		IS_NULLABLE,
-		COLUMN_KEY
+		COLUMN_KEY,
+		ORDINAL_POSITION
 		FROM information_schema.columns
-		WHERE TABLE_NAME='%s'
-		AND TABLE_SCHEMA='%s'`, t, schema)
+		WHERE TABLE_NAME = '%s'
+		AND TABLE_SCHEMA = '%s'
+		ORDER BY ORDINAL_POSITION `, table, schema)
 
-		tableSchema := TableSchema{t, nil, ""}
+	rows, err := db.Queryx(q)
+	if err != nil {
+		return nil, err
+	}
 
-		rows, err := db.Queryx(q)
+	// iterate over the rows
+	for rows.Next() {
+
+		var c ColumnSchema
+
+		err = rows.StructScan(&c)
+
 		if err != nil {
 			return nil, err
 		}
 
-		// iterate over the rows
-		for rows.Next() {
-
-			var c ColumnSchema
-
-			err = rows.StructScan(&c)
-
-			if err != nil {
-				return nil, err
-			}
-
-			// Current way to check if a column is a primary key
-			// might need to add more or totally refactor this stuff
-			if c.ColumnKey == "PRI" {
-				tableSchema.PrimaryKey = c.ColumnName
-			}
-
-			tableSchema.Columns = append(tableSchema.Columns, c)
+		// Current way to check if a column is a primary key
+		// might need to add more or totally refactor this stuff
+		if c.ColumnKey == "PRI" {
+			tableSchema.PrimaryKey = c.ColumnName
 		}
 
-		results = append(results, tableSchema)
+		tableSchema.Columns = append(tableSchema.Columns, c)
 	}
 
-	return results, nil
+	return &tableSchema, nil
+}
+
+// QueryTable ...
+func QueryTable(db *sqlx.DB, ts TableSchema) ([]map[string]interface{}, error) {
+
+	var res []map[string]interface{}
+
+	sql := ts.QueryAll()
+
+	rows, err := db.Queryx(sql)
+	if err != nil {
+		return nil, err
+	}
+
+	for rows.Next() {
+
+		var newRow []interface{}
+
+		//
+		for _, t := range ts.Columns {
+			switch t.DataType {
+			case "text":
+				var d string
+				newRow = append(newRow, &d)
+			case "int":
+				var d int
+				newRow = append(newRow, &d)
+			default:
+				log.Fatal("bad data type")
+			}
+		}
+
+		err = rows.Scan(newRow...)
+
+		var m = make(map[string]interface{})
+
+		for i, item := range newRow {
+			switch item.(type) {
+			case *int:
+				m[ts.ColumnNames()[i]] = reflect.ValueOf(item).Elem().Int()
+			case *string:
+				m[ts.ColumnNames()[i]] = reflect.ValueOf(item).Elem().String()
+			default:
+				log.Println("unhandled type")
+			}
+			if ts.ColumnNames()[i] == ts.PrimaryKey {
+				// If this column is the PK; assign it again to a special key in our map
+				m["__pk"] = fmt.Sprintf("%v", m[ts.ColumnNames()[i]])
+			}
+
+		}
+
+		res = append(res, m)
+
+	}
+
+	return res, nil
+
+}
+
+// WriteKV writes data to levelDB.
+func WriteKV(ldb *leveldb.DB, schema, table, pk, sep string, data map[string]interface{}) error {
+
+	key := []byte(strings.Join([]string{schema, table, pk}, sep))
+
+	value, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+
+	return ldb.Put(key, value, nil)
+
 }

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -1,39 +1,105 @@
 package sql2kv
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 )
 
-func TestGetTableSchemas(t *testing.T) {
+func TestGetTableSchema(t *testing.T) {
 
-	ts := []TableSchema{
-		TableSchema{"users",
-			[]ColumnSchema{
-				{"test", "users", "id", "int", "NO", "PRI"},
-				{"test", "users", "name", "text", "YES", ""},
-				{"test", "users", "age", "int", "YES", ""},
+	ts := []struct {
+		name string
+		in   string
+		out  *TableSchema
+	}{
+		{
+
+			"Testing Basic User Schema",
+			"users",
+			&TableSchema{
+				"test",
+				"users",
+				[]ColumnSchema{
+					{"test", "users", "id", "int", "NO", "PRI", 1},
+					{"test", "users", "name", "text", "YES", "", 2},
+					{"test", "users", "age", "int", "YES", "", 3},
+				},
+				"id",
 			},
-			"id",
 		},
 	}
 
-	results, err := GetTableSchemas(testMysqlDb, "test", []string{"users", "addresses"})
-	if err != nil {
-		t.Errorf("Get Table Schema Failed due to %v", err)
-	}
+	for _, ts := range ts {
 
-	if len(results) != 2 {
-		t.Errorf("Expected %v got %v", 2, len(results))
-		t.FailNow()
-	}
+		actual, err := GetTableSchema(testMySQLDB, "test", ts.in)
+		if err != nil {
+			t.Errorf("Get Table Schema Failed due to %v", err)
+		}
 
-	for i, _ := range ts {
-		if !reflect.DeepEqual(ts[i], results[i]) {
-			t.Errorf("\n Expected: %v \n, Acutal: %v \n", ts[i], results[i])
+		if !reflect.DeepEqual(ts.out, actual) {
+			t.Errorf("\n Expected: %v \n, Acutal: %v \n", ts.out, actual)
 			t.FailNow()
 
 		}
 	}
+}
 
+func TestQueryTableAndWriteKV(t *testing.T) {
+
+	var ts = TableSchema{
+		"test",
+		"users",
+		[]ColumnSchema{
+			{"test", "users", "id", "int", "NO", "PRI", 1},
+			{"test", "users", "name", "text", "YES", "", 2},
+			{"test", "users", "age", "int", "YES", "", 3},
+		},
+		"id",
+	}
+
+	rows, err := QueryTable(testMySQLDB, ts)
+	if err != nil {
+		t.Errorf("error from QueryTable %v", err)
+	}
+
+	row := rows[0]
+
+	if row["name"].(string) != "Farhan" {
+		t.Errorf("Expected name Farhan got %s", row["name"].(string))
+	}
+	if row["age"].(int64) != 32 {
+		t.Errorf("Expected age 32 got %v", row["row"].(int64))
+	}
+
+	err = WriteKV(testLevelDB, "test", "users", row["__pk"].(string), "!", row)
+	if err != nil {
+		t.Errorf("error from WriteKV: %v", err)
+	}
+
+	k := []byte("test!users!1")
+
+	found, err := testLevelDB.Get(k, nil)
+	if err != nil {
+		t.Errorf("could not find key: %v", err)
+	}
+
+	var unmarshaled map[string]interface{}
+	if err := json.Unmarshal(found, &unmarshaled); err != nil {
+		t.Error(err)
+	}
+
+	if unmarshaled["name"].(string) != "Farhan" {
+		t.Errorf("expected to unmarshal name Farhan, got: %s", unmarshaled["name"].(string))
+	}
+
+	// JSON only marhsals as float64 for type numeric.
+	if unmarshaled["age"].(float64) != 32 {
+		t.Errorf("expected to unmarshal age 32, got: %v", unmarshaled["age"].(float64))
+	}
+
+	// Test string representation of our special key, the primary key.
+	if unmarshaled["__pk"].(string) != "1" {
+		t.Errorf("Expected __pk to be 1, got: %s", unmarshaled["__pk"].(string))
+	}
 }


### PR DESCRIPTION
Render rows from SQL as []map[string]interface{}

For each row we need to allocate a scannable []interface{} and the
map[string]interface{} that we return.

The map has a special key "__pk" to store a string representation of the
row's primary key.

LevelDB is a test global, and it should write it's state under /tmp.